### PR TITLE
简单的命令脚本比较检测缺少的中文翻译

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# Composer
+/vendor
+/composer.lock

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,13 @@
         "source": "https://github.com/jsthon/flarum-ext-simplified-chinese"
     },
     "require": {
-        "flarum/core": "^0.1.0-beta.5"
+        "flarum/core": "^0.1.0-beta.5",
+        "flarum/flarum-ext-english": "^0.1.0@dev"
+    },
+    "autoload": {
+        "psr-4": {
+            "Flarum\\SimplifiedChinese\\": "src/"
+        }
     },
     "extra": {
         "flarum-extension": {
@@ -31,5 +37,6 @@
             "code": "zh",
             "title": "简体中文"
         }
-    }
+    },
+    "minimum-stability": "dev"
 }

--- a/console
+++ b/console
@@ -1,0 +1,11 @@
+#!/usr/bin/env php
+<?php
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+use Flarum\SimplifiedChinese\Commands\DiffCommand;
+use Symfony\Component\Console\Application;
+
+$app = new Application();
+$app->add(new DiffCommand());
+$app->run();

--- a/src/Commands/DiffCommand.php
+++ b/src/Commands/DiffCommand.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Flarum\SimplifiedChinese\Commands;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Yaml\Yaml;
+
+class DiffCommand extends Command
+{
+    /**
+     * The base directory of this project.
+     *
+     * @var string
+     */
+    protected $baseDir;
+
+    /**
+     * Configure current command.
+     */
+    protected function configure()
+    {
+        $this->setName("diff:locale")
+             ->setDescription("Check the lack of chinese translation.")
+             ->setHelp("This command will check the lack of chinese translation by comparing the locales with flarum/flarum-ext-english.");
+    }
+
+
+    /**
+     * Execute the current command.
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return int|null|void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->baseDir  = dirname(dirname(__DIR__));
+        $chineseLocales = $this->dotLocales($this->baseDir . '/locale');
+        $englishLocales = $this->dotLocales($this->baseDir . '/vendor/flarum/flarum-ext-english/locale');
+
+        $output->writeln("<fg=green>+++++++++++++++++++++++</>");
+        foreach ($englishLocales as $key => $value) {
+            if ( ! array_key_exists($key, $chineseLocales)) {
+                $output->writeln("<fg=green>$key: $value</>");
+            }
+        }
+
+        $output->writeln("<fg=red>-----------------------</>");
+        foreach ($chineseLocales as $key => $value) {
+            if ( ! array_key_exists($key, $englishLocales)) {
+                $output->writeln("<fg=red>$key: $value</>");
+            }
+        }
+    }
+
+    /**
+     * Parse locales and doted the contents.
+     *
+     * @param $dir
+     *
+     * @return array
+     */
+    protected function dotLocales($dir)
+    {
+        $results = [];
+        $dirp    = opendir($dir);
+        while ($file = readdir($dirp)) {
+            if (preg_match("/.*\.yml/", $file)) {
+                $content = Yaml::parse(file_get_contents($dir . '/' . $file));
+                $results = array_merge($results, array_dot($content));
+            }
+        }
+
+        return $results;
+    }
+}


### PR DESCRIPTION
 添加了一个用于检测中文和英文词条差异的简单命令，这样可以方便的保持跟上游的词条同步。
