### PR TITLE
同步 flarum-ext-english

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "Simplified Chinese language pack.",
     "keywords": ["locale"],
     "license": "MIT",
-    "version": "v0.1.0-beta.5",
+    "version": "v0.1.0-beta.6",
     "authors": [
         {
             "name": "Jsthon Wong",
@@ -15,7 +15,7 @@
         "source": "https://github.com/jsthon/flarum-ext-simplified-chinese"
     },
     "require": {
-        "flarum/core": "^0.1.0-beta.5"
+        "flarum/core": "^0.1.0-beta.6"
     },
     "extra": {
         "flarum-extension": {

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -225,6 +225,7 @@ core:
       delete_forever_button: => core.ref.delete_forever
       log_in_to_reply_button: 登入以回复
       rename_button: => core.ref.rename
+      rename_text: "输入新的标题："
       reply_button: => core.ref.reply
       restore_button: => core.ref.restore
 

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -224,8 +224,7 @@ core:
       delete_confirmation: "确定删除这个话题？"
       delete_forever_button: => core.ref.delete_forever
       log_in_to_reply_button: 登入以回复
-      rename_button: 更改标题
-      rename_text: "输入新的标题："
+      rename_button: => core.ref.rename
       reply_button: => core.ref.reply
       restore_button: => core.ref.restore
 
@@ -334,6 +333,11 @@ core:
       load_more_button: => core.ref.load_more
       reply_placeholder: => core.ref.write_a_reply
       time_lapsed_text: "{period} 后"
+
+    # These translations are used by the rename discussion modal.
+    rename_discussion:
+      title: 输入新的标题
+      submit_button: => core.ref.rename
 
     # These translations are used by the search results dropdown list.
     search:
@@ -447,6 +451,10 @@ core:
       submit_button: 重置密码
       title: => core.ref.reset_your_password
 
+  # Translations in this namespace are used in messages output by the API.
+  api:
+    invalid_username_message: "用户名只能包含字母、数字和连字符。"
+
   # Translations in this namespace are used in emails sent by the forum.
   email:
 
@@ -480,7 +488,7 @@ core:
 
     # These translations are used in emails sent when users ask to reset their passwords.
     reset_password:
-      subject: 重置你的密码
+      subject: => core.ref.reset_your_password
       body: |
         Hey {username} !
 
@@ -517,6 +525,7 @@ core:
     notifications: 消息通知
     okay: 完成                                     # Referenced by flarum-tags.yml
     password: 密码
+    rename: 更改标题
     reply: 回复                                # Referenced by flarum-mentions.yml
     reset_your_password: 重置密码
     restore: 恢复
@@ -529,9 +538,9 @@ core:
     write_a_reply: 说点什么...
     you: 你                                     # Referenced by flarum-likes.yml, flarum-mentions.yml
 
-   ##
-   # GROUP NAMES - These keys are translated at the back end.
-   ##
+  ##
+  # GROUP NAMES - These keys are translated at the back end.
+  ##
 
   # Translations in this namespace are used to translate default group names.
   group:

--- a/locale/flarum-approval.yml
+++ b/locale/flarum-approval.yml
@@ -22,7 +22,7 @@ flarum-approval:
 
     # These translations are displayed in the post header.
     post:
-      awaiting_approval_text: 等待审核中
+      awaiting_approval_text: => flarum-approval.ref.awaiting_approval
 
     # These translations are used by the post control buttons.
     post_controls:
@@ -34,4 +34,4 @@ flarum-approval:
 
   # Translations in this namespace are referenced by two or more unique keys.
   ref:
-    awaiting_approval: 等待审核
+    awaiting_approval: 等待审核中

--- a/locale/flarum-flags.yml
+++ b/locale/flarum-flags.yml
@@ -52,7 +52,7 @@ flarum-flags:
       flag_button: 报告
 
   ##
-  # REUSED STRINGS - These keys should not be used directly in code!
+  # REUSED TRANSLATIONS - These keys should not be used directly in code!
   ##
 
   # Translations in this namespace are referenced by two or more unique keys.

--- a/locale/flarum-sticky.yml
+++ b/locale/flarum-sticky.yml
@@ -20,7 +20,7 @@ flarum-sticky:
 
     # These translations are used by the discussion control buttons.
     discussion_controls:
-      sticky_button: 置顶话题
+      sticky_button: => flarum-sticky.ref.sticky
       unsticky_button: 取消置顶
 
     # These translations are displayed between posts in the post stream.
@@ -29,7 +29,7 @@ flarum-sticky:
       discussion_unstickied_text: "{username} 取消置顶话题"
 
   ##
-  # REUSED STRINGS - These keys should not be used directly in code!
+  # REUSED TRANSLATIONS - These keys should not be used directly in code!
   ##
 
   # Translations in this namespace are referenced by two or more unique keys.

--- a/locale/flarum-subscriptions.yml
+++ b/locale/flarum-subscriptions.yml
@@ -44,7 +44,7 @@ flarum-subscriptions:
       notify_email_tooltip: 有新回复时发送邮件
 
   ##
-  # REUSED STRINGS - These keys should not be used directly in code!
+  # REUSED TRANSLATIONS - These keys should not be used directly in code!
   ##
 
   # Translations in this namespace are referenced by two or more unique keys.

--- a/locale/flarum-tags.yml
+++ b/locale/flarum-tags.yml
@@ -87,11 +87,11 @@ flarum-tags:
   # Translations in this namespace are used by the forum and admin interfaces.
   lib:
 
-    # This translation displayed in place of the name of a tag that's been deleted.
+    # This translation is displayed in place of the name of a tag that's been deleted.
     deleted_tag_text: 已删除
 
   ##
-  # REUSED STRINGS - These keys should not be used directly in code!
+  # REUSED TRANSLATIONS - These keys should not be used directly in code!
   ##
 
   # Translations in this namespace are referenced by two or more unique keys.

--- a/locale/validation.yml
+++ b/locale/validation.yml
@@ -78,7 +78,3 @@ validation:
     name_plural: 复数名称
     tag_count_primary: number of primary tags
     tag_count_secondary: number of secondary tags
-
-  custom:
-    username:
-      regex: "用户名只能含有字母、数字、连字符。"

--- a/locale/validation.yml
+++ b/locale/validation.yml
@@ -78,3 +78,7 @@ validation:
     name_plural: 复数名称
     tag_count_primary: number of primary tags
     tag_count_secondary: number of secondary tags
+
+  custom:
+    username:
+      regex: "用户名只能包含字母、数字和连字符。"


### PR DESCRIPTION
目前flarum-ext-simplified-chinese还没有发布 beta 6（#21） 。这个版本同步了当前最新的 https://github.com/flarum/flarum-ext-english/commit/b8f92630817bae03c1973a92e107811461b837d5 ，但因为 https://github.com/flarum/flarum-ext-english/commit/b8f92630817bae03c1973a92e107811461b837d5 在 beta 6 的基础上删除了一些词条，所以为了向后兼容 beta 6，这个版本在之前的基础上只增改不减，等 beta 7 出来的时候可以再删除掉多余的项。